### PR TITLE
fix WithHTTPClient useless

### DIFF
--- a/rest/wazuh.go
+++ b/rest/wazuh.go
@@ -269,13 +269,6 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 		userAgent: "go-wazuh",
 	}
 
-	// mutate client and add all optional params
-	for _, o := range opts {
-		if err := o(c); err != nil {
-			return nil, err
-		}
-	}
-
 	if c.ctx == nil {
 		c.ctx = context.Background()
 	}
@@ -301,6 +294,13 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	}
 	c.innerClient = &http.Client{
 		Transport: &t,
+	}
+
+	// mutate client and add all optional params
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			return nil, err
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
The NewClient function initializes a new http.Client after applying the ClientOption functions, which renders the WithHTTPClient option ineffective. This PR moves the initialization of the http.Client before applying the options, ensuring that WithHTTPClient and other custom configurations work as intended.